### PR TITLE
change_stripe_test_keys_definition_in_config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,6 +61,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.stripe.secret_key = Rails.application.credentials.stripe[:development][:secret_key]
-  config.stripe.publishable_key = Rails.application.credentials.stripe[:development][:publishable_key]
+  config.x.stripe.secret_key = Rails.application.credentials.stripe[:development][:secret_key]
+  config.x.stripe.publishable_key = Rails.application.credentials.stripe[:development][:publishable_key]
 end


### PR DESCRIPTION
- make definition of stripe test API keys correct