### PR TITLE
add_admin_namespace

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 require 'create_product/create_product.rb'
-class ProductsController < ApplicationController
+class Admin::ProductsController < ApplicationController
   before_action :find_product, except: [:index, :new, :create]
 
   def index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :products
-  resources :plans
+
+  namespace :admin do
+    resources :products
+    resources :plans
+  end
+  
   resources :subscriptions
   resources :customers
 end


### PR DESCRIPTION
- add admin namespace
Reason: to avoid extra logic of access division in common views 