### PR TITLE
create_admin_namespace

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,5 +1,5 @@
 require 'create_plan/create_plan.rb'
-class PlansController < ApplicationController
+class Admin::PlansController < ApplicationController
  
   def create
     result = CreateStripePlan.call(

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 require 'create_product/create_product.rb'
-class ProductsController < ApplicationController
+class Admin::ProductsController < ApplicationController
   before_action :find_product, except: [:index, :new, :create]
 
   def index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :products
-  resources :plans
+
+  namespace :admin do
+    resources :products
+    resources :plans
+  end
+  
   resources :subscriptions
   resources :customers
 end


### PR DESCRIPTION
- create admin namespace with products and plan routes
Reason: avoid usage of views' parts access restrictions
